### PR TITLE
Fix Decoding Loop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,12 @@ pub fn decompress(compressed: &[u8], max_uncompressed_length: usize) -> Vec<u8> 
     let mut bytes_read = 0;
 
     // adapted from https://github.com/image-rs/image-tiff/blob/master/src/decoder/stream.rs#L248
-    while bytes_read < compressed.len() && uncompressed.len() < max_uncompressed_length {
+    while uncompressed.len() < max_uncompressed_length { 
         let bytes_written = uncompressed.len();
 
         // Resize vector only if needed
         uncompressed.reserve(1 << 12);
-        let buffer_space = uncompressed.capacity();
+        let buffer_space = uncompressed.capacity().min(max_uncompressed_length);
         // Initialize unwritten bytes with zeros
         uncompressed.resize(buffer_space, 0u8);
 


### PR DESCRIPTION
See : https://github.com/image-rs/image-tiff/pull/108 for the mirrored change for the fix to https://github.com/image-rs/image-tiff/issues/106.

To test, you can try this script in node before and after this change (I use `node-fetch`):
```javascript
(async () => {
  const { decompress } = require("./index.cjs");
  const fetch = require("node-fetch");
  const options = { headers: { Range: "bytes=1453622266-1453681751" } };
  const res = await fetch(
    "https://viv-demo.storage.googleapis.com/001_20x0.36x_638_GAP43_series.pyramid.ome.tiff",
    options
  );
  const buf = await res.buffer();
  // Tile size is 512 x 512
  const uncompressed = await decompress(buf, 512 * 512);
  console.log(uncompressed);
})();

```
Without this PR's change, the example should yield an array of length `262141` just short of the desired `512 * 512 = 262144`
